### PR TITLE
Implement `zeroedref()` and generate accessor methods for the UCX structs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,10 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-runtest@v1
+        env:
+          # Don't allow other transports like infiniband in CI because the
+          # github runners seem to have flaky support for them.
+          UCX_TLS: 'tcp,sm'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/res/Project.toml
+++ b/res/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 UCX_jll = "16e4e860-d6b8-5056-a518-93e88b6392ae"

--- a/res/epilogue.jl
+++ b/res/epilogue.jl
@@ -1,0 +1,5 @@
+# Defined here rather than in the prologue because it uses `ucs_status_t`, which
+# is defined after the prologue.
+struct UCXException <: Exception
+    status::ucs_status_t
+end

--- a/res/prologue.jl
+++ b/res/prologue.jl
@@ -9,3 +9,49 @@ const sa_family_t = Cushort
 # FIXME: Clang.jl should have defined this
 UCS_BIT(i) = (UInt(1) << (convert(UInt, i)))
 UCP_VERSION(_major, _minor) = (((_major) << UCP_VERSION_MAJOR_SHIFT) | ((_minor) << UCP_VERSION_MINOR_SHIFT))
+
+
+macro check(ex)
+    quote
+        status = $(esc(ex))
+        if status !== UCS_OK
+            throw(UCXException(status))
+        end
+    end
+end
+
+# Gleefully stolen from GPUToolbox.jl:
+# https://github.com/JuliaGPU/GPUToolbox.jl/blob/f971bcdeb2cd8096333549e6563cf03a76459ae2/src/ccalls.jl#L19
+#
+# Macro for wrapping a function definition returning a status code. Two versions
+# of the function will be generated: `foo`, which does a safety check on the
+# status code, and `unchecked_foo` where the status code is directly returned to
+# the caller.
+macro checked(ex)
+    # parse the function definition
+    @assert Meta.isexpr(ex, :function)
+    sig = ex.args[1]
+    @assert Meta.isexpr(sig, :call)
+    body = ex.args[2]
+    @assert Meta.isexpr(body, :block)
+
+    # make sure these functions are inlined
+    pushfirst!(body.args, Expr(:meta, :inline))
+
+    # generate a "safe" version that performs a check
+    safe_body = quote
+        @inline
+        ret = $body
+        @check ret
+
+        ret
+    end
+    safe_sig = Expr(:call, sig.args[1], sig.args[2:end]...)
+    safe_def = Expr(:function, safe_sig, safe_body)
+
+    # generate a "unchecked" version that returns the error code instead
+    unchecked_sig = Expr(:call, Symbol("unchecked_", sig.args[1]), sig.args[2:end]...)
+    unchecked_def = Expr(:function, unchecked_sig, body)
+
+    return esc(:($safe_def, $unchecked_def))
+end

--- a/res/wrap.jl
+++ b/res/wrap.jl
@@ -1,13 +1,9 @@
 using Clang.Generators
 using UCX_jll
+using MacroTools: @capture, postwalk, prettify
+using JuliaFormatter: format_file
 
 include_dir = joinpath(UCX_jll.artifact_dir ,"include")
-
-options = load_options(joinpath(@__DIR__, "wrap.toml"))
-
-args = get_default_args()
-push!(args, "-I$include_dir")
-
 headers = [joinpath(include_dir, "ucp", "api", header) for header in ["ucp.h"]]
 
 @add_def socklen_t
@@ -16,5 +12,49 @@ headers = [joinpath(include_dir, "ucp", "api", header) for header in ["ucp.h"]]
 @add_def sockaddr_storage
 @add_def FILE
 
-ctx = create_context(headers, args, options)
-build!(ctx)
+# Functions that return `ucs_status_t` are wrapped so that they throw a
+# `UCXException` (see epilogue.jl) on a non-`UCS_OK` status.
+function rewrite_status_check(expr)
+    if !(expr isa Expr) || !@capture(expr, function fname_(fargs__) fbody__ end)
+        return expr
+    end
+
+    # Find the return type of the @ccall in the body
+    rettype = nothing
+    postwalk(expr) do x
+        if @capture(x, @ccall(inner_)) && @capture(inner, _::rt_)
+            rettype = rt
+        end
+        x
+    end
+    if rettype !== :ucs_status_t
+        return expr
+    end
+
+    newfunc = :(@checked $expr)
+
+    return prettify(newfunc)
+end
+
+function rewrite!(ctx)
+    for node in ctx.dag.nodes
+        for i in eachindex(node.exprs)
+            node.exprs[i] = rewrite_status_check(node.exprs[i])
+        end
+    end
+end
+
+cd(@__DIR__) do
+    args = get_default_args("x86_64-linux-gnu")
+    push!(args, "-I$include_dir")
+
+    options = load_options(joinpath(@__DIR__, "wrap.toml"))
+
+    ctx = create_context(headers, args, options)
+
+    build!(ctx, BUILDSTAGE_NO_PRINTING)
+    rewrite!(ctx)
+    build!(ctx, BUILDSTAGE_PRINTING_ONLY)
+
+    format_file("../src/api.jl"; margin=120)
+end

--- a/res/wrap.toml
+++ b/res/wrap.toml
@@ -4,6 +4,7 @@ output_file_path = "../src/api.jl"
 smart_de_anonymize = true
 use_deterministic_symbol = true
 prologue_file_path = "./prologue.jl"
+epilogue_file_path = "./epilogue.jl"
 module_name = "API"
 
 [codegen]

--- a/src/UCX.jl
+++ b/src/UCX.jl
@@ -77,11 +77,16 @@ end
     return reinterpret(Ptr{fieldtype(T, field)}, ptr)
 end
 
-@inline function set!(ref::Ref{T}, fieldname, val) where T
-    GC.@preserve ref begin
+# Allocate a zeroed `Ref{T}` and set the given fields
+function zeroedref(::Type{T}; kwargs...) where T
+    ref = Ref{T}()
+    memzero!(ref)
+
+    for (fieldname, val) in kwargs
         Base.unsafe_store!(unsafe_fieldptr(ref, fieldname), val)
     end
-    val
+
+    return ref
 end
 
 # Exceptions/Status
@@ -89,7 +94,7 @@ end
 uintptr_t(ptr::Ptr) = reinterpret(UInt, ptr)
 uintptr_t(status::API.ucs_status_t) = reinterpret(UInt, convert(Int, status))
 
-UCS_PTR_STATUS(ptr::Ptr{Cvoid}) = API.ucs_status_t(reinterpret(UInt, ptr)) 
+UCS_PTR_STATUS(ptr::Ptr{Cvoid}) = API.ucs_status_t(reinterpret(UInt, ptr))
 UCS_PTR_IS_ERR(ptr::Ptr{Cvoid}) = uintptr_t(ptr) >= uintptr_t(API.UCS_ERR_LAST)
 UCS_PTR_IS_PTR(ptr::Ptr{Cvoid}) = (uintptr_t(ptr) - 1) < (uintptr_t(API.UCS_ERR_LAST) - 1)
 
@@ -144,10 +149,7 @@ end
 
 function query()
     field_mask = API.UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL
-    r_attr = Ref{API.ucp_lib_attr_t}()
-
-    memzero!(r_attr)
-    set!(r_attr, :field_mask, field_mask)
+    r_attr = zeroedref(API.ucp_lib_attr_t; field_mask)
 
     @check API.ucp_lib_query(r_attr)
     r_attr[]
@@ -245,14 +247,7 @@ mutable struct UCXContext
                         API.UCP_FEATURE_RMA
         end
 
-        params = Ref{API.ucp_params}()
-        memzero!(params)
-        set!(params, :field_mask,      field_mask)
-        set!(params, :features,        features)
-
-        if shared
-            set!(params, :mt_workers_shared, true)
-        end
+        params = zeroedref(API.ucp_params; field_mask, features, mt_workers_shared=shared)
 
         config = UCXConfig(; kwargs...)
 
@@ -292,10 +287,7 @@ end
 
 function query(ctx::UCXContext)
     field_mask = API.UCP_ATTR_FIELD_THREAD_MODE
-    r_attr = Ref{API.ucp_context_attr_t}()
-
-    memzero!(r_attr)
-    set!(r_attr, :field_mask, field_mask)
+    r_attr = zeroedref(API.ucp_context_attr_t; field_mask)
 
     @check API.ucp_context_query(ctx, r_attr)
     r_attr[]
@@ -319,10 +311,7 @@ mutable struct UCXWorker
         field_mask  = API.UCP_WORKER_PARAM_FIELD_THREAD_MODE
         thread_mode = API.UCS_THREAD_MODE_MULTI
 
-        params = Ref{API.ucp_worker_params}()
-        memzero!(params)
-        set!(params, :field_mask,  field_mask)
-        set!(params, :thread_mode, thread_mode)
+        params = zeroedref(API.ucp_worker_params; field_mask, thread_mode)
 
         @debug "Creating UCXWorker" thread_mode progress_mode
 
@@ -353,10 +342,7 @@ Base.unsafe_convert(::Type{API.ucp_worker_h}, worker::UCXWorker) = worker.handle
 function query(worker::UCXWorker)
     field_mask = API.UCP_WORKER_ATTR_FIELD_THREAD_MODE |
                  API.UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER
-    r_attr = Ref{API.ucp_worker_attr_t}()
-
-    memzero!(r_attr)
-    set!(r_attr, :field_mask, field_mask)
+    r_attr = zeroedref(API.ucp_worker_attr_t; field_mask)
     API.ucp_worker_query(worker, r_attr)
     r_attr[]
 end
@@ -534,12 +520,7 @@ function AMHandler(worker::UCXWorker, func, id)
                   API.UCP_AM_HANDLER_PARAM_FIELD_CB |
                   API.UCP_AM_HANDLER_PARAM_FIELD_ARG
 
-    params = Ref{API.ucp_am_handler_param_t}()
-    memzero!(params)
-    set!(params, :field_mask, field_mask)
-    set!(params, :id,         id)
-    set!(params, :cb,         cb)
-    set!(params, :arg,        arg)
+    params = zeroedref(API.ucp_am_handler_param_t; field_mask, id, cb, arg)
 
     @check API.ucp_worker_set_am_recv_handler(worker, params)
 end
@@ -551,12 +532,7 @@ function delete_am!(worker::UCXWorker, id)
                   API.UCP_AM_HANDLER_PARAM_FIELD_CB |
                   API.UCP_AM_HANDLER_PARAM_FIELD_ARG
 
-    params = Ref{API.ucp_am_handler_param_t}()
-    memzero!(params)
-    set!(params, :field_mask, field_mask)
-    set!(params, :id,         id)
-    set!(params, :cb,         C_NULL)
-    set!(params, :arg,        C_NULL)
+    params = zeroedref(API.ucp_am_handler_param_t; field_mask, id, cb=C_NULL, arg=C_NULL)
 
     @check API.ucp_worker_set_am_recv_handler(worker, params)
 end
@@ -632,14 +608,10 @@ function UCXEndpoint(worker::UCXWorker, ip::IPv4, port)
         addrlen = sizeof(IP.sockaddr_in)
         ucs_sockaddr = API.ucs_sock_addr(reinterpret(Ptr{API.sockaddr}, ptr), addrlen)
 
-        params = Ref{API.ucp_ep_params}()
-        memzero!(params)
-        set!(params, :field_mask,   field_mask)
-        set!(params, :sockaddr,     ucs_sockaddr)
-        set!(params, :flags,        flags)
+        params = zeroedref(API.ucp_ep_params; field_mask, sockaddr=ucs_sockaddr, flags)
 
         # TODO: Error callback
-    
+
         @check API.ucp_ep_create(worker, params, r_handle)
     end
 
@@ -651,11 +623,7 @@ function UCXEndpoint(worker::UCXWorker, conn_request::UCXConnectionRequest)
                  API.UCP_EP_PARAM_FIELD_CONN_REQUEST
     flags      = API.UCP_EP_PARAMS_FLAGS_NO_LOOPBACK
 
-    params = Ref{API.ucp_ep_params}()
-    memzero!(params)
-    set!(params, :field_mask,   field_mask)
-    set!(params, :conn_request, conn_request.handle)
-    set!(params, :flags,        flags)
+    params = zeroedref(API.ucp_ep_params; field_mask, conn_request=conn_request.handle, flags)
 
     # TODO: Error callback
 
@@ -682,10 +650,7 @@ function _UCXEndpoint(worker::UCXWorker, addr::Ptr{API.ucp_address_t})
     field_mask = API.UCP_EP_PARAM_FIELD_REMOTE_ADDRESS
 
     r_handle = Ref{API.ucp_ep_h}()
-    params = Ref{API.ucp_ep_params}()
-    memzero!(params)
-    set!(params, :field_mask,   field_mask)
-    set!(params, :address,      addr)
+    params = zeroedref(API.ucp_ep_params; field_mask, address=addr)
 
     # TODO: Error callback
 
@@ -730,11 +695,7 @@ mutable struct UCXListener
             addrlen = sizeof(IP.sockaddr_in)
             ucs_sockaddr = API.ucs_sock_addr(reinterpret(Ptr{API.sockaddr}, ptr), addrlen)
 
-            params = Ref{API.ucp_listener_params}()
-            memzero!(params)
-            set!(params, :field_mask, field_mask)
-            set!(params, :sockaddr, ucs_sockaddr)
-            set!(params, :conn_handler, conn_handler)
+            params = zeroedref(API.ucp_listener_params; field_mask, sockaddr=ucs_sockaddr, conn_handler)
 
             @check API.ucp_listener_create(worker, params, r_handle)
         end
@@ -772,20 +733,7 @@ mutable struct Memory
     function Memory(ctx::UCXContext, obj, addr::Ptr, length)
         field_mask = API.UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
                      API.UCP_MEM_MAP_PARAM_FIELD_LENGTH
-
-        # if data === nothing
-        #     @assert addr == C_NULL
-        #     field_mask |= API.UCP_MEM_MAP_PARAM_FIELD_FLAGS
-        # end
-        
-        params = Ref{API.ucp_mem_map_params}()
-        memzero!(params)
-        set!(params, :field_mask,   field_mask)
-        set!(params, :address,      addr)
-        set!(params, :length,       length)
-        # if data === nothing
-        #     set!(params, :flags, API.UCP_MEM_MAP_NONBLOCK | API.UCP_MEM_MAP_ALLOCATE)
-        # end
+        params = zeroedref(API.ucp_mem_map_params; field_mask, address=addr, length)
 
         r_handle = Ref{API.ucp_mem_h}()
         @check API.ucp_mem_map(ctx, params, r_handle)

--- a/src/UCX.jl
+++ b/src/UCX.jl
@@ -223,7 +223,7 @@ mutable struct UCXContext
             field_mask |= API.UCP_PARAM_FIELD_MT_WORKERS_SHARED
         end
 
-        features = zero(CEnum.basetype(UCX.API.ucp_feature))
+        features = zero(CEnum.basetype(API.ucp_feature))
         if wakeup
             features |= API.UCP_FEATURE_WAKEUP
         end
@@ -332,7 +332,7 @@ mutable struct UCXWorker
 
         # TODO: Verify that UCXContext has been created with WAKEUP
         if progress_mode === :polling
-            r_fd = Ref{API.Cint}()
+            r_fd = Ref{Cint}()
             @check API.ucp_worker_get_efd(handle, r_fd)
             fd = Libc.RawFD(r_fd[])
         else
@@ -695,7 +695,7 @@ function _UCXEndpoint(worker::UCXWorker, addr::Ptr{API.ucp_address_t})
 end
 
 function listener_callback(conn_request_h::API.ucp_conn_request_h, args::Ptr{Cvoid})
-    conn_request = UCX.UCXConnectionRequest(conn_request_h)
+    conn_request = UCXConnectionRequest(conn_request_h)
     listener = Base.unsafe_pointer_to_objref(args)::UCXListener
     Base.invokelatest(listener.callback, listener, conn_request)
     nothing
@@ -806,7 +806,7 @@ end
 
 ##
 # RemoteKey
-## 
+##
 
 mutable struct RemoteKey
     handle::API.ucp_rkey_h
@@ -968,7 +968,7 @@ function send(ep::UCXEndpoint, buffer, nbytes, tag)
     end
 end
 
-function recv(worker::UCXWorker, buffer, nbytes, tag, tag_mask=~zero(UCX.API.ucp_tag_t))
+function recv(worker::UCXWorker, buffer, nbytes, tag, tag_mask=~zero(API.ucp_tag_t))
     dt = ucp_dt_make_contig(1) # since we are receiving nbytes
     request = UCXRequest(worker, buffer) # rooted through worker
     cb = @cfunction(recv_callback, Cvoid, (Ptr{Cvoid}, API.ucs_status_t, Ptr{API.ucp_tag_recv_info_t}, Ptr{Cvoid}))
@@ -1204,17 +1204,17 @@ end
 tag(kind, seed, port) = hash(kind, hash(seed, hash(port)))
 
 function Endpoint(worker::Worker, addr, port)
-    ep = UCX.UCXEndpoint(worker.worker, addr, port)
+    ep = UCXEndpoint(worker.worker, addr, port)
     Endpoint(worker, ep, false)
 end
 
 function Endpoint(worker::Worker, connection::UCXConnectionRequest)
-    ep = UCX.UCXEndpoint(worker.worker, connection)
+    ep = UCXEndpoint(worker.worker, connection)
     Endpoint(worker, ep, true)
 end
 
 function Endpoint(worker::Worker, ep::UCXEndpoint, listener)
-    seed = rand(UInt128) 
+    seed = rand(UInt128)
     pid = getpid()
     msg_tag = tag(:ctrl, seed, pid)
 

--- a/src/UCX.jl
+++ b/src/UCX.jl
@@ -15,6 +15,9 @@ else
 end
 
 include("api.jl")
+
+using .API: UCXException
+
 include("ip.jl")
 
 function __init__()
@@ -98,18 +101,7 @@ UCS_PTR_STATUS(ptr::Ptr{Cvoid}) = API.ucs_status_t(reinterpret(UInt, ptr))
 UCS_PTR_IS_ERR(ptr::Ptr{Cvoid}) = uintptr_t(ptr) >= uintptr_t(API.UCS_ERR_LAST)
 UCS_PTR_IS_PTR(ptr::Ptr{Cvoid}) = (uintptr_t(ptr) - 1) < (uintptr_t(API.UCS_ERR_LAST) - 1)
 
-struct UCXException <: Exception
-    status::API.ucs_status_t
-end
-
-macro check(ex)
-    quote
-        status = $(esc(ex))
-        if status != API.UCS_OK
-            throw(UCXException(status))
-        end
-    end
-end
+using .API: @check
 
 # Utils
 
@@ -151,7 +143,7 @@ function query()
     field_mask = API.UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL
     r_attr = zeroedref(API.ucp_lib_attr_t; field_mask)
 
-    @check API.ucp_lib_query(r_attr)
+    API.ucp_lib_query(r_attr)
     r_attr[]
 end
 
@@ -164,7 +156,7 @@ mutable struct UCXConfig
 
     function UCXConfig(; kwargs...)
         r_handle = Ref{Ptr{API.ucp_config_t}}()
-        @check API.ucp_config_read(C_NULL, C_NULL, r_handle) # XXX: Prefix is broken
+        API.ucp_config_read(C_NULL, C_NULL, r_handle) # XXX: Prefix is broken
 
         config = new(r_handle[])
         finalizer(config) do config
@@ -181,7 +173,7 @@ end
 Base.unsafe_convert(::Type{Ptr{API.ucp_config_t}}, config::UCXConfig) = config.handle
 
 function Base.setindex!(config::UCXConfig, value::String, key::Union{String, Symbol})
-    @check API.ucp_config_modify(config, key, value)
+    API.ucp_config_modify(config, key, value)
     return value
 end
 
@@ -253,8 +245,8 @@ mutable struct UCXContext
 
         r_handle = Ref{API.ucp_context_h}()
         # UCP.ucp_init is a header function so we call, UCP.ucp_init_version
-        @check API.ucp_init_version(API.UCP_API_MAJOR, API.UCP_API_MINOR,
-                                    params, config, r_handle)
+        API.ucp_init_version(API.UCP_API_MAJOR, API.UCP_API_MINOR,
+                             params, config, r_handle)
 
         context = new(r_handle[], features, parse(Dict, config))
 
@@ -289,7 +281,7 @@ function query(ctx::UCXContext)
     field_mask = API.UCP_ATTR_FIELD_THREAD_MODE
     r_attr = zeroedref(API.ucp_context_attr_t; field_mask)
 
-    @check API.ucp_context_query(ctx, r_attr)
+    API.ucp_context_query(ctx, r_attr)
     r_attr[]
 end
 
@@ -316,13 +308,13 @@ mutable struct UCXWorker
         @debug "Creating UCXWorker" thread_mode progress_mode
 
         r_handle = Ref{API.ucp_worker_h}()
-        @check API.ucp_worker_create(context, params, r_handle)
+        API.ucp_worker_create(context, params, r_handle)
         handle = r_handle[]
 
         # TODO: Verify that UCXContext has been created with WAKEUP
         if progress_mode === :polling
             r_fd = Ref{Cint}()
-            @check API.ucp_worker_get_efd(handle, r_fd)
+            API.ucp_worker_get_efd(handle, r_fd)
             fd = Libc.RawFD(r_fd[])
         else
             fd = RawFD(-1)
@@ -384,7 +376,7 @@ function progress(worker::UCXWorker, allow_yield=true)
 end
 
 function fence(worker::UCXWorker)
-    @check API.ucp_worker_fence(worker)
+    API.ucp_worker_fence(worker)
 end
 
 function lock_am(worker::UCXWorker)
@@ -418,7 +410,7 @@ function Base.wait(worker::UCXWorker)
             end
 
             # Wait for poll
-            status = API.ucp_worker_arm(worker)
+            status = API.unchecked_ucp_worker_arm(worker)
             if status == API.UCS_OK
                 if !isopen(worker)
                     error("UCXWorker already closed")
@@ -456,7 +448,7 @@ end
 function Base.notify(worker::UCXWorker)
     # If we don't use polling, we can't signal the worker
     if ispolling(worker)
-        @check API.ucp_worker_signal(worker)
+        API.ucp_worker_signal(worker)
     end
 end
 
@@ -522,7 +514,7 @@ function AMHandler(worker::UCXWorker, func, id)
 
     params = zeroedref(API.ucp_am_handler_param_t; field_mask, id, cb, arg)
 
-    @check API.ucp_worker_set_am_recv_handler(worker, params)
+    API.ucp_worker_set_am_recv_handler(worker, params)
 end
 
 function delete_am!(worker::UCXWorker, id)
@@ -534,7 +526,7 @@ function delete_am!(worker::UCXWorker, id)
 
     params = zeroedref(API.ucp_am_handler_param_t; field_mask, id, cb=C_NULL, arg=C_NULL)
 
-    @check API.ucp_worker_set_am_recv_handler(worker, params)
+    API.ucp_worker_set_am_recv_handler(worker, params)
 end
 
 function am_data_release(worker::UCXWorker, data)
@@ -549,7 +541,7 @@ mutable struct UCXAddress
     function UCXAddress(worker::UCXWorker)
         addr = Ref{Ptr{API.ucp_address_t}}()
         len = Ref{Csize_t}()
-        @check API.ucp_worker_get_address(worker, addr, len)
+        API.ucp_worker_get_address(worker, addr, len)
 
         this = new(worker, addr[], len[])
         finalizer(this) do addr
@@ -580,7 +572,7 @@ mutable struct UCXEndpoint
                 @async_showerr begin
                     status = API.ucp_ep_close_nb(handle, API.UCP_EP_CLOSE_MODE_FLUSH)
                     if UCS_PTR_IS_PTR(status)
-                        while API.ucp_request_check_status(status) == API.UCS_INPROGRESS
+                        while API.unchecked_ucp_request_check_status(status) == API.UCS_INPROGRESS
                             progress(worker)
                             yield()
                         end
@@ -612,7 +604,7 @@ function UCXEndpoint(worker::UCXWorker, ip::IPv4, port)
 
         # TODO: Error callback
 
-        @check API.ucp_ep_create(worker, params, r_handle)
+        API.ucp_ep_create(worker, params, r_handle)
     end
 
     UCXEndpoint(worker, r_handle[])
@@ -628,7 +620,7 @@ function UCXEndpoint(worker::UCXWorker, conn_request::UCXConnectionRequest)
     # TODO: Error callback
 
     r_handle = Ref{API.ucp_ep_h}()
-    @check API.ucp_ep_create(worker, params, r_handle)
+    API.ucp_ep_create(worker, params, r_handle)
 
     UCXEndpoint(worker, r_handle[])
 end
@@ -654,7 +646,7 @@ function _UCXEndpoint(worker::UCXWorker, addr::Ptr{API.ucp_address_t})
 
     # TODO: Error callback
 
-    @check API.ucp_ep_create(worker, params, r_handle)
+    API.ucp_ep_create(worker, params, r_handle)
 
     UCXEndpoint(worker, r_handle[])
 end
@@ -697,7 +689,7 @@ mutable struct UCXListener
 
             params = zeroedref(API.ucp_listener_params; field_mask, sockaddr=ucs_sockaddr, conn_handler)
 
-            @check API.ucp_listener_create(worker, params, r_handle)
+            API.ucp_listener_create(worker, params, r_handle)
         end
 
         this.handle = r_handle[]
@@ -712,7 +704,7 @@ end
 Base.unsafe_convert(::Type{API.ucp_listener_h}, listener::UCXListener) = listener.handle
 
 function reject(listener::UCXListener, conn_request::UCXConnectionRequest)
-    @check API.ucp_listener_reject(listener, conn_request.handle)
+    API.ucp_listener_reject(listener, conn_request.handle)
 end
 
 function ucp_dt_make_contig(elem_size)
@@ -736,12 +728,12 @@ mutable struct Memory
         params = zeroedref(API.ucp_mem_map_params; field_mask, address=addr, length)
 
         r_handle = Ref{API.ucp_mem_h}()
-        @check API.ucp_mem_map(ctx, params, r_handle)
+        API.ucp_mem_map(ctx, params, r_handle)
 
         base = UInt64(reinterpret(UInt, addr))
         this = new(r_handle[], ctx, base, obj)
         finalizer(this) do memory
-            API.ucp_mem_unmap(memory.ctx, memory)
+            API.unchecked_ucp_mem_unmap(memory.ctx, memory)
         end
         this
     end
@@ -761,7 +753,7 @@ mutable struct RemoteKey
 
     function RemoteKey(ep::UCXEndpoint, buffer)
         r_rkey = Ref{API.ucp_rkey_h}()
-        @check API.ucp_ep_rkey_unpack(ep, buffer, r_rkey)
+        API.ucp_ep_rkey_unpack(ep, buffer, r_rkey)
         this = new(r_rkey[])
         finalizer(this) do rkey
             API.ucp_rkey_destroy(rkey)
@@ -774,7 +766,7 @@ Base.unsafe_convert(::Type{API.ucp_rkey_h}, rkey::RemoteKey) = rkey.handle
 function rkey_pack(memory::Memory)
     r_data = Ref{Ptr{Cvoid}}()
     r_size = Ref{Csize_t}()
-    @check API.ucp_rkey_pack(memory.ctx, memory, r_data, r_size)
+    API.ucp_rkey_pack(memory.ctx, memory, r_data, r_size)
     buffer = copy(unsafe_wrap(Array{UInt8}, Base.unsafe_convert(Ptr{UInt8}, r_data[]), r_size[] % Int, own=false))
     API.ucp_rkey_buffer_release(r_data[])
     return buffer
@@ -782,7 +774,7 @@ end
 
 function Base.pointer(rkey::RemoteKey, raddr::UInt64)
     r_ptr = Ref{Ptr{Cvoid}}()
-    @check API.ucp_rkey_ptr(rkey, raddr, r_ptr)
+    API.ucp_rkey_ptr(rkey, raddr, r_ptr)
     return r_ptr[]
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -15,9 +15,55 @@ UCS_BIT(i) = (UInt(1) << (convert(UInt, i)))
 UCP_VERSION(_major, _minor) = (((_major) << UCP_VERSION_MAJOR_SHIFT) | ((_minor) << UCP_VERSION_MINOR_SHIFT))
 
 
+macro check(ex)
+    quote
+        status = $(esc(ex))
+        if status !== UCS_OK
+            throw(UCXException(status))
+        end
+    end
+end
+
+# Gleefully stolen from GPUToolbox.jl:
+# https://github.com/JuliaGPU/GPUToolbox.jl/blob/f971bcdeb2cd8096333549e6563cf03a76459ae2/src/ccalls.jl#L19
+#
+# Macro for wrapping a function definition returning a status code. Two versions
+# of the function will be generated: `foo`, which does a safety check on the
+# status code, and `unchecked_foo` where the status code is directly returned to
+# the caller.
+macro checked(ex)
+    # parse the function definition
+    @assert Meta.isexpr(ex, :function)
+    sig = ex.args[1]
+    @assert Meta.isexpr(sig, :call)
+    body = ex.args[2]
+    @assert Meta.isexpr(body, :block)
+
+    # make sure these functions are inlined
+    pushfirst!(body.args, Expr(:meta, :inline))
+
+    # generate a "safe" version that performs a check
+    safe_body = quote
+        @inline
+        ret = $body
+        @check ret
+
+        ret
+    end
+    safe_sig = Expr(:call, sig.args[1], sig.args[2:end]...)
+    safe_def = Expr(:function, safe_sig, safe_body)
+
+    # generate a "unchecked" version that returns the error code instead
+    unchecked_sig = Expr(:call, Symbol("unchecked_", sig.args[1]), sig.args[2:end]...)
+    unchecked_def = Expr(:function, unchecked_sig, body)
+
+    return esc(:($safe_def, $unchecked_def))
+end
+
+
 struct sockaddr
     sa_family::sa_family_t
-    sa_data::NTuple{14, Cchar}
+    sa_data::NTuple{14,Cchar}
 end
 
 @cenum ucs_status_t::Int8 begin
@@ -59,7 +105,7 @@ end
 const ucs_cpu_mask_t = Culong
 
 struct ucs_cpu_set_t
-    ucs_bits::NTuple{16, ucs_cpu_mask_t}
+    ucs_bits::NTuple{16,ucs_cpu_mask_t}
 end
 
 const ucp_datatype_t = UInt64
@@ -181,7 +227,7 @@ const ucs_sock_addr_t = ucs_sock_addr
 
 struct ucs_log_component_config
     log_level::ucs_log_level_t
-    name::NTuple{16, Cchar}
+    name::NTuple{16,Cchar}
     file_filter::Ptr{Cchar}
 end
 
@@ -388,72 +434,131 @@ function ucp_request_alloc(worker)
     @ccall libucp.ucp_request_alloc(worker::ucp_worker_h)::Ptr{Cvoid}
 end
 
-function ucp_request_test(request, info)
+@checked function ucp_request_test(request, info)
     @ccall libucp.ucp_request_test(request::Ptr{Cvoid}, info::Ptr{ucp_tag_recv_info_t})::ucs_status_t
 end
 
-function ucp_rkey_pack(context, memh, rkey_buffer_p, size_p)
-    @ccall libucp.ucp_rkey_pack(context::ucp_context_h, memh::ucp_mem_h, rkey_buffer_p::Ptr{Ptr{Cvoid}}, size_p::Ptr{Csize_t})::ucs_status_t
+@checked function ucp_rkey_pack(context, memh, rkey_buffer_p, size_p)
+    @ccall libucp.ucp_rkey_pack(
+        context::ucp_context_h,
+        memh::ucp_mem_h,
+        rkey_buffer_p::Ptr{Ptr{Cvoid}},
+        size_p::Ptr{Csize_t},
+    )::ucs_status_t
 end
 
 function ucp_rkey_buffer_release(rkey_buffer)
     @ccall libucp.ucp_rkey_buffer_release(rkey_buffer::Ptr{Cvoid})::Cvoid
 end
 
-function ucp_ep_flush(ep)
+@checked function ucp_ep_flush(ep)
     @ccall libucp.ucp_ep_flush(ep::ucp_ep_h)::ucs_status_t
 end
 
-function ucp_worker_flush(worker)
+@checked function ucp_worker_flush(worker)
     @ccall libucp.ucp_worker_flush(worker::ucp_worker_h)::ucs_status_t
 end
 
-function ucp_put(ep, buffer, length, remote_addr, rkey)
-    @ccall libucp.ucp_put(ep::ucp_ep_h, buffer::Ptr{Cvoid}, length::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
+@checked function ucp_put(ep, buffer, length, remote_addr, rkey)
+    @ccall libucp.ucp_put(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        length::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+    )::ucs_status_t
 end
 
-function ucp_get(ep, buffer, length, remote_addr, rkey)
-    @ccall libucp.ucp_get(ep::ucp_ep_h, buffer::Ptr{Cvoid}, length::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
+@checked function ucp_get(ep, buffer, length, remote_addr, rkey)
+    @ccall libucp.ucp_get(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        length::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+    )::ucs_status_t
 end
 
-function ucp_atomic_add32(ep, add, remote_addr, rkey)
+@checked function ucp_atomic_add32(ep, add, remote_addr, rkey)
     @ccall libucp.ucp_atomic_add32(ep::ucp_ep_h, add::UInt32, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
 end
 
-function ucp_atomic_add64(ep, add, remote_addr, rkey)
+@checked function ucp_atomic_add64(ep, add, remote_addr, rkey)
     @ccall libucp.ucp_atomic_add64(ep::ucp_ep_h, add::UInt64, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
 end
 
-function ucp_atomic_fadd32(ep, add, remote_addr, rkey, result)
-    @ccall libucp.ucp_atomic_fadd32(ep::ucp_ep_h, add::UInt32, remote_addr::UInt64, rkey::ucp_rkey_h, result::Ptr{UInt32})::ucs_status_t
+@checked function ucp_atomic_fadd32(ep, add, remote_addr, rkey, result)
+    @ccall libucp.ucp_atomic_fadd32(
+        ep::ucp_ep_h,
+        add::UInt32,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        result::Ptr{UInt32},
+    )::ucs_status_t
 end
 
-function ucp_atomic_fadd64(ep, add, remote_addr, rkey, result)
-    @ccall libucp.ucp_atomic_fadd64(ep::ucp_ep_h, add::UInt64, remote_addr::UInt64, rkey::ucp_rkey_h, result::Ptr{UInt64})::ucs_status_t
+@checked function ucp_atomic_fadd64(ep, add, remote_addr, rkey, result)
+    @ccall libucp.ucp_atomic_fadd64(
+        ep::ucp_ep_h,
+        add::UInt64,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        result::Ptr{UInt64},
+    )::ucs_status_t
 end
 
-function ucp_atomic_swap32(ep, swap, remote_addr, rkey, result)
-    @ccall libucp.ucp_atomic_swap32(ep::ucp_ep_h, swap::UInt32, remote_addr::UInt64, rkey::ucp_rkey_h, result::Ptr{UInt32})::ucs_status_t
+@checked function ucp_atomic_swap32(ep, swap, remote_addr, rkey, result)
+    @ccall libucp.ucp_atomic_swap32(
+        ep::ucp_ep_h,
+        swap::UInt32,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        result::Ptr{UInt32},
+    )::ucs_status_t
 end
 
-function ucp_atomic_swap64(ep, swap, remote_addr, rkey, result)
-    @ccall libucp.ucp_atomic_swap64(ep::ucp_ep_h, swap::UInt64, remote_addr::UInt64, rkey::ucp_rkey_h, result::Ptr{UInt64})::ucs_status_t
+@checked function ucp_atomic_swap64(ep, swap, remote_addr, rkey, result)
+    @ccall libucp.ucp_atomic_swap64(
+        ep::ucp_ep_h,
+        swap::UInt64,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        result::Ptr{UInt64},
+    )::ucs_status_t
 end
 
-function ucp_atomic_cswap32(ep, compare, swap, remote_addr, rkey, result)
-    @ccall libucp.ucp_atomic_cswap32(ep::ucp_ep_h, compare::UInt32, swap::UInt32, remote_addr::UInt64, rkey::ucp_rkey_h, result::Ptr{UInt32})::ucs_status_t
+@checked function ucp_atomic_cswap32(ep, compare, swap, remote_addr, rkey, result)
+    @ccall libucp.ucp_atomic_cswap32(
+        ep::ucp_ep_h,
+        compare::UInt32,
+        swap::UInt32,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        result::Ptr{UInt32},
+    )::ucs_status_t
 end
 
-function ucp_atomic_cswap64(ep, compare, swap, remote_addr, rkey, result)
-    @ccall libucp.ucp_atomic_cswap64(ep::ucp_ep_h, compare::UInt64, swap::UInt64, remote_addr::UInt64, rkey::ucp_rkey_h, result::Ptr{UInt64})::ucs_status_t
+@checked function ucp_atomic_cswap64(ep, compare, swap, remote_addr, rkey, result)
+    @ccall libucp.ucp_atomic_cswap64(
+        ep::ucp_ep_h,
+        compare::UInt64,
+        swap::UInt64,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        result::Ptr{UInt64},
+    )::ucs_status_t
 end
 
 function ucp_ep_modify_nb(ep, params)
     @ccall libucp.ucp_ep_modify_nb(ep::ucp_ep_h, params::Ptr{ucp_ep_params_t})::ucs_status_ptr_t
 end
 
-function ucp_worker_get_address(worker, address_p, address_length_p)
-    @ccall libucp.ucp_worker_get_address(worker::ucp_worker_h, address_p::Ptr{Ptr{ucp_address_t}}, address_length_p::Ptr{Csize_t})::ucs_status_t
+@checked function ucp_worker_get_address(worker, address_p, address_length_p)
+    @ccall libucp.ucp_worker_get_address(
+        worker::ucp_worker_h,
+        address_p::Ptr{Ptr{ucp_address_t}},
+        address_length_p::Ptr{Csize_t},
+    )::ucs_status_t
 end
 
 function ucp_ep_close_nb(ep, mode)
@@ -464,60 +569,159 @@ function ucp_ep_flush_nb(ep, flags, cb)
     @ccall libucp.ucp_ep_flush_nb(ep::ucp_ep_h, flags::Cuint, cb::ucp_send_callback_t)::ucs_status_ptr_t
 end
 
-function ucp_worker_set_am_handler(worker, id, cb, arg, flags)
-    @ccall libucp.ucp_worker_set_am_handler(worker::ucp_worker_h, id::UInt16, cb::ucp_am_callback_t, arg::Ptr{Cvoid}, flags::UInt32)::ucs_status_t
+@checked function ucp_worker_set_am_handler(worker, id, cb, arg, flags)
+    @ccall libucp.ucp_worker_set_am_handler(
+        worker::ucp_worker_h,
+        id::UInt16,
+        cb::ucp_am_callback_t,
+        arg::Ptr{Cvoid},
+        flags::UInt32,
+    )::ucs_status_t
 end
 
 function ucp_am_send_nb(ep, id, buffer, count, datatype, cb, flags)
-    @ccall libucp.ucp_am_send_nb(ep::ucp_ep_h, id::UInt16, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, cb::ucp_send_callback_t, flags::Cuint)::ucs_status_ptr_t
+    @ccall libucp.ucp_am_send_nb(
+        ep::ucp_ep_h,
+        id::UInt16,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        cb::ucp_send_callback_t,
+        flags::Cuint,
+    )::ucs_status_ptr_t
 end
 
 function ucp_stream_send_nb(ep, buffer, count, datatype, cb, flags)
-    @ccall libucp.ucp_stream_send_nb(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, cb::ucp_send_callback_t, flags::Cuint)::ucs_status_ptr_t
+    @ccall libucp.ucp_stream_send_nb(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        cb::ucp_send_callback_t,
+        flags::Cuint,
+    )::ucs_status_ptr_t
 end
 
 function ucp_stream_recv_nb(ep, buffer, count, datatype, cb, length, flags)
-    @ccall libucp.ucp_stream_recv_nb(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, cb::ucp_stream_recv_callback_t, length::Ptr{Csize_t}, flags::Cuint)::ucs_status_ptr_t
+    @ccall libucp.ucp_stream_recv_nb(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        cb::ucp_stream_recv_callback_t,
+        length::Ptr{Csize_t},
+        flags::Cuint,
+    )::ucs_status_ptr_t
 end
 
 function ucp_tag_send_nb(ep, buffer, count, datatype, tag, cb)
-    @ccall libucp.ucp_tag_send_nb(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, tag::ucp_tag_t, cb::ucp_send_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_send_nb(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        tag::ucp_tag_t,
+        cb::ucp_send_callback_t,
+    )::ucs_status_ptr_t
 end
 
-function ucp_tag_send_nbr(ep, buffer, count, datatype, tag, req)
-    @ccall libucp.ucp_tag_send_nbr(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, tag::ucp_tag_t, req::Ptr{Cvoid})::ucs_status_t
+@checked function ucp_tag_send_nbr(ep, buffer, count, datatype, tag, req)
+    @ccall libucp.ucp_tag_send_nbr(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        tag::ucp_tag_t,
+        req::Ptr{Cvoid},
+    )::ucs_status_t
 end
 
 function ucp_tag_send_sync_nb(ep, buffer, count, datatype, tag, cb)
-    @ccall libucp.ucp_tag_send_sync_nb(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, tag::ucp_tag_t, cb::ucp_send_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_send_sync_nb(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        tag::ucp_tag_t,
+        cb::ucp_send_callback_t,
+    )::ucs_status_ptr_t
 end
 
 function ucp_tag_recv_nb(worker, buffer, count, datatype, tag, tag_mask, cb)
-    @ccall libucp.ucp_tag_recv_nb(worker::ucp_worker_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, tag::ucp_tag_t, tag_mask::ucp_tag_t, cb::ucp_tag_recv_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_recv_nb(
+        worker::ucp_worker_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        tag::ucp_tag_t,
+        tag_mask::ucp_tag_t,
+        cb::ucp_tag_recv_callback_t,
+    )::ucs_status_ptr_t
 end
 
-function ucp_tag_recv_nbr(worker, buffer, count, datatype, tag, tag_mask, req)
-    @ccall libucp.ucp_tag_recv_nbr(worker::ucp_worker_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, tag::ucp_tag_t, tag_mask::ucp_tag_t, req::Ptr{Cvoid})::ucs_status_t
+@checked function ucp_tag_recv_nbr(worker, buffer, count, datatype, tag, tag_mask, req)
+    @ccall libucp.ucp_tag_recv_nbr(
+        worker::ucp_worker_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        tag::ucp_tag_t,
+        tag_mask::ucp_tag_t,
+        req::Ptr{Cvoid},
+    )::ucs_status_t
 end
 
 function ucp_tag_msg_recv_nb(worker, buffer, count, datatype, message, cb)
-    @ccall libucp.ucp_tag_msg_recv_nb(worker::ucp_worker_h, buffer::Ptr{Cvoid}, count::Csize_t, datatype::ucp_datatype_t, message::ucp_tag_message_h, cb::ucp_tag_recv_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_msg_recv_nb(
+        worker::ucp_worker_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        datatype::ucp_datatype_t,
+        message::ucp_tag_message_h,
+        cb::ucp_tag_recv_callback_t,
+    )::ucs_status_ptr_t
 end
 
-function ucp_put_nbi(ep, buffer, length, remote_addr, rkey)
-    @ccall libucp.ucp_put_nbi(ep::ucp_ep_h, buffer::Ptr{Cvoid}, length::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
+@checked function ucp_put_nbi(ep, buffer, length, remote_addr, rkey)
+    @ccall libucp.ucp_put_nbi(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        length::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+    )::ucs_status_t
 end
 
 function ucp_put_nb(ep, buffer, length, remote_addr, rkey, cb)
-    @ccall libucp.ucp_put_nb(ep::ucp_ep_h, buffer::Ptr{Cvoid}, length::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h, cb::ucp_send_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_put_nb(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        length::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        cb::ucp_send_callback_t,
+    )::ucs_status_ptr_t
 end
 
-function ucp_get_nbi(ep, buffer, length, remote_addr, rkey)
-    @ccall libucp.ucp_get_nbi(ep::ucp_ep_h, buffer::Ptr{Cvoid}, length::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
+@checked function ucp_get_nbi(ep, buffer, length, remote_addr, rkey)
+    @ccall libucp.ucp_get_nbi(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        length::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+    )::ucs_status_t
 end
 
 function ucp_get_nb(ep, buffer, length, remote_addr, rkey, cb)
-    @ccall libucp.ucp_get_nb(ep::ucp_ep_h, buffer::Ptr{Cvoid}, length::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h, cb::ucp_send_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_get_nb(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        length::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        cb::ucp_send_callback_t,
+    )::ucs_status_ptr_t
 end
 
 @cenum ucp_atomic_post_op_t::UInt32 begin
@@ -528,8 +732,15 @@ end
     UCP_ATOMIC_POST_OP_LAST = 4
 end
 
-function ucp_atomic_post(ep, opcode, value, op_size, remote_addr, rkey)
-    @ccall libucp.ucp_atomic_post(ep::ucp_ep_h, opcode::ucp_atomic_post_op_t, value::UInt64, op_size::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h)::ucs_status_t
+@checked function ucp_atomic_post(ep, opcode, value, op_size, remote_addr, rkey)
+    @ccall libucp.ucp_atomic_post(
+        ep::ucp_ep_h,
+        opcode::ucp_atomic_post_op_t,
+        value::UInt64,
+        op_size::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+    )::ucs_status_t
 end
 
 @cenum ucp_atomic_fetch_op_t::UInt32 begin
@@ -543,7 +754,16 @@ end
 end
 
 function ucp_atomic_fetch_nb(ep, opcode, value, result, op_size, remote_addr, rkey, cb)
-    @ccall libucp.ucp_atomic_fetch_nb(ep::ucp_ep_h, opcode::ucp_atomic_fetch_op_t, value::UInt64, result::Ptr{Cvoid}, op_size::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h, cb::ucp_send_callback_t)::ucs_status_ptr_t
+    @ccall libucp.ucp_atomic_fetch_nb(
+        ep::ucp_ep_h,
+        opcode::ucp_atomic_fetch_op_t,
+        value::UInt64,
+        result::Ptr{Cvoid},
+        op_size::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        cb::ucp_send_callback_t,
+    )::ucs_status_ptr_t
 end
 
 function ucp_worker_flush_nb(worker, flags, cb)
@@ -856,7 +1076,7 @@ struct ucp_context_attr
     request_size::Csize_t
     thread_mode::ucs_thread_mode_t
     memory_types::UInt64
-    name::NTuple{32, Cchar}
+    name::NTuple{32,Cchar}
     device_counter_size::Csize_t
 end
 
@@ -869,7 +1089,7 @@ struct ucp_worker_attr
     address::Ptr{ucp_address_t}
     address_length::Csize_t
     max_am_header::Csize_t
-    name::NTuple{32, Cchar}
+    name::NTuple{32,Cchar}
     max_debug_string::Csize_t
 end
 
@@ -916,7 +1136,7 @@ end
 struct sockaddr_storage
     ss_family::sa_family_t
     __ss_align::Culong
-    __ss_padding::NTuple{112, Cchar}
+    __ss_padding::NTuple{112,Cchar}
 end
 
 struct ucp_listener_attr
@@ -947,7 +1167,7 @@ struct ucp_stream_poll_ep
     ep::ucp_ep_h
     user_data::Ptr{Cvoid}
     flags::Cuint
-    reserved::NTuple{16, UInt8}
+    reserved::NTuple{16,UInt8}
 end
 
 const ucp_stream_poll_ep_t = ucp_stream_poll_ep
@@ -965,7 +1185,7 @@ end
 const ucp_mem_map_params_t = ucp_mem_map_params
 
 struct __JL_Ctag_6
-    data::NTuple{8, UInt8}
+    data::NTuple{8,UInt8}
 end
 
 function Base.getproperty(x::Ptr{__JL_Ctag_6}, f::Symbol)
@@ -989,14 +1209,14 @@ end
 
 function Base.propertynames(x::__JL_Ctag_6, private::Bool = false)
     (:send, :recv, :recv_stream, :recv_am, if private
-            fieldnames(typeof(x))
-        else
-            ()
-        end...)
+        fieldnames(typeof(x))
+    else
+        ()
+    end...)
 end
 
 struct __JL_Ctag_7
-    data::NTuple{8, UInt8}
+    data::NTuple{8,UInt8}
 end
 
 function Base.getproperty(x::Ptr{__JL_Ctag_7}, f::Symbol)
@@ -1018,14 +1238,14 @@ end
 
 function Base.propertynames(x::__JL_Ctag_7, private::Bool = false)
     (:length, :tag_info, if private
-            fieldnames(typeof(x))
-        else
-            ()
-        end...)
+        fieldnames(typeof(x))
+    else
+        ()
+    end...)
 end
 
 struct ucp_request_param_t
-    data::NTuple{72, UInt8}
+    data::NTuple{72,UInt8}
 end
 
 function Base.getproperty(x::Ptr{ucp_request_param_t}, f::Symbol)
@@ -1054,11 +1274,23 @@ function Base.setproperty!(x::Ptr{ucp_request_param_t}, f::Symbol, v)
 end
 
 function Base.propertynames(x::ucp_request_param_t, private::Bool = false)
-    (:op_attr_mask, :flags, :request, :cb, :datatype, :user_data, :reply_buffer, :memory_type, :recv_info, :memh, if private
+    (
+        :op_attr_mask,
+        :flags,
+        :request,
+        :cb,
+        :datatype,
+        :user_data,
+        :reply_buffer,
+        :memory_type,
+        :recv_info,
+        :memh,
+        if private
             fieldnames(typeof(x))
         else
             ()
-        end...)
+        end...,
+    )
 end
 
 struct ucp_request_attr_t
@@ -1079,67 +1311,100 @@ end
 
 const ucp_am_handler_param_t = ucp_am_handler_param
 
-function ucp_lib_query(attr)
+@checked function ucp_lib_query(attr)
     @ccall libucp.ucp_lib_query(attr::Ptr{ucp_lib_attr_t})::ucs_status_t
 end
 
-function ucp_config_read(env_prefix, filename, config_p)
-    @ccall libucp.ucp_config_read(env_prefix::Ptr{Cchar}, filename::Ptr{Cchar}, config_p::Ptr{Ptr{ucp_config_t}})::ucs_status_t
+@checked function ucp_config_read(env_prefix, filename, config_p)
+    @ccall libucp.ucp_config_read(
+        env_prefix::Ptr{Cchar},
+        filename::Ptr{Cchar},
+        config_p::Ptr{Ptr{ucp_config_t}},
+    )::ucs_status_t
 end
 
 function ucp_config_release(config)
     @ccall libucp.ucp_config_release(config::Ptr{ucp_config_t})::Cvoid
 end
 
-function ucp_config_modify(config, name, value)
+@checked function ucp_config_modify(config, name, value)
     @ccall libucp.ucp_config_modify(config::Ptr{ucp_config_t}, name::Ptr{Cchar}, value::Ptr{Cchar})::ucs_status_t
 end
 
 function ucp_config_print(config, stream, title, print_flags)
-    @ccall libucp.ucp_config_print(config::Ptr{ucp_config_t}, stream::Ptr{FILE}, title::Ptr{Cchar}, print_flags::ucs_config_print_flags_t)::Cvoid
+    @ccall libucp.ucp_config_print(
+        config::Ptr{ucp_config_t},
+        stream::Ptr{FILE},
+        title::Ptr{Cchar},
+        print_flags::ucs_config_print_flags_t,
+    )::Cvoid
 end
 
 function ucp_get_version(major_version, minor_version, release_number)
-    @ccall libucp.ucp_get_version(major_version::Ptr{Cuint}, minor_version::Ptr{Cuint}, release_number::Ptr{Cuint})::Cvoid
+    @ccall libucp.ucp_get_version(
+        major_version::Ptr{Cuint},
+        minor_version::Ptr{Cuint},
+        release_number::Ptr{Cuint},
+    )::Cvoid
 end
 
 function ucp_get_version_string()
     @ccall libucp.ucp_get_version_string()::Ptr{Cchar}
 end
 
-function ucp_init_version(api_major_version, api_minor_version, params, config, context_p)
-    @ccall libucp.ucp_init_version(api_major_version::Cuint, api_minor_version::Cuint, params::Ptr{ucp_params_t}, config::Ptr{ucp_config_t}, context_p::Ptr{ucp_context_h})::ucs_status_t
+@checked function ucp_init_version(api_major_version, api_minor_version, params, config, context_p)
+    @ccall libucp.ucp_init_version(
+        api_major_version::Cuint,
+        api_minor_version::Cuint,
+        params::Ptr{ucp_params_t},
+        config::Ptr{ucp_config_t},
+        context_p::Ptr{ucp_context_h},
+    )::ucs_status_t
 end
 
-function ucp_init(params, config, context_p)
-    @ccall libucp.ucp_init(params::Ptr{ucp_params_t}, config::Ptr{ucp_config_t}, context_p::Ptr{ucp_context_h})::ucs_status_t
+@checked function ucp_init(params, config, context_p)
+    @ccall libucp.ucp_init(
+        params::Ptr{ucp_params_t},
+        config::Ptr{ucp_config_t},
+        context_p::Ptr{ucp_context_h},
+    )::ucs_status_t
 end
 
 function ucp_cleanup(context_p)
     @ccall libucp.ucp_cleanup(context_p::ucp_context_h)::Cvoid
 end
 
-function ucp_context_query(context_p, attr)
+@checked function ucp_context_query(context_p, attr)
     @ccall libucp.ucp_context_query(context_p::ucp_context_h, attr::Ptr{ucp_context_attr_t})::ucs_status_t
 end
 
-function ucp_rkey_compare(worker, rkey1, rkey2, params, result)
-    @ccall libucp.ucp_rkey_compare(worker::ucp_worker_h, rkey1::ucp_rkey_h, rkey2::ucp_rkey_h, params::Ptr{ucp_rkey_compare_params_t}, result::Ptr{Cint})::ucs_status_t
+@checked function ucp_rkey_compare(worker, rkey1, rkey2, params, result)
+    @ccall libucp.ucp_rkey_compare(
+        worker::ucp_worker_h,
+        rkey1::ucp_rkey_h,
+        rkey2::ucp_rkey_h,
+        params::Ptr{ucp_rkey_compare_params_t},
+        result::Ptr{Cint},
+    )::ucs_status_t
 end
 
 function ucp_context_print_info(context, stream)
     @ccall libucp.ucp_context_print_info(context::ucp_context_h, stream::Ptr{FILE})::Cvoid
 end
 
-function ucp_worker_create(context, params, worker_p)
-    @ccall libucp.ucp_worker_create(context::ucp_context_h, params::Ptr{ucp_worker_params_t}, worker_p::Ptr{ucp_worker_h})::ucs_status_t
+@checked function ucp_worker_create(context, params, worker_p)
+    @ccall libucp.ucp_worker_create(
+        context::ucp_context_h,
+        params::Ptr{ucp_worker_params_t},
+        worker_p::Ptr{ucp_worker_h},
+    )::ucs_status_t
 end
 
 function ucp_worker_destroy(worker)
     @ccall libucp.ucp_worker_destroy(worker::ucp_worker_h)::Cvoid
 end
 
-function ucp_worker_query(worker, attr)
+@checked function ucp_worker_query(worker, attr)
     @ccall libucp.ucp_worker_query(worker::ucp_worker_h, attr::Ptr{ucp_worker_attr_t})::ucs_status_t
 end
 
@@ -1151,8 +1416,11 @@ function ucp_worker_release_address(worker, address)
     @ccall libucp.ucp_worker_release_address(worker::ucp_worker_h, address::Ptr{ucp_address_t})::Cvoid
 end
 
-function ucp_worker_address_query(address, attr)
-    @ccall libucp.ucp_worker_address_query(address::Ptr{ucp_address_t}, attr::Ptr{ucp_worker_address_attr_t})::ucs_status_t
+@checked function ucp_worker_address_query(address, attr)
+    @ccall libucp.ucp_worker_address_query(
+        address::Ptr{ucp_address_t},
+        attr::Ptr{ucp_worker_address_attr_t},
+    )::ucs_status_t
 end
 
 function ucp_worker_progress(worker)
@@ -1160,14 +1428,19 @@ function ucp_worker_progress(worker)
 end
 
 function ucp_stream_worker_poll(worker, poll_eps, max_eps, flags)
-    @ccall libucp.ucp_stream_worker_poll(worker::ucp_worker_h, poll_eps::Ptr{ucp_stream_poll_ep_t}, max_eps::Csize_t, flags::Cuint)::Cssize_t
+    @ccall libucp.ucp_stream_worker_poll(
+        worker::ucp_worker_h,
+        poll_eps::Ptr{ucp_stream_poll_ep_t},
+        max_eps::Csize_t,
+        flags::Cuint,
+    )::Cssize_t
 end
 
-function ucp_worker_get_efd(worker, fd)
+@checked function ucp_worker_get_efd(worker, fd)
     @ccall libucp.ucp_worker_get_efd(worker::ucp_worker_h, fd::Ptr{Cint})::ucs_status_t
 end
 
-function ucp_worker_wait(worker)
+@checked function ucp_worker_wait(worker)
     @ccall libucp.ucp_worker_wait(worker::ucp_worker_h)::ucs_status_t
 end
 
@@ -1175,35 +1448,42 @@ function ucp_worker_wait_mem(worker, address)
     @ccall libucp.ucp_worker_wait_mem(worker::ucp_worker_h, address::Ptr{Cvoid})::Cvoid
 end
 
-function ucp_worker_arm(worker)
+@checked function ucp_worker_arm(worker)
     @ccall libucp.ucp_worker_arm(worker::ucp_worker_h)::ucs_status_t
 end
 
-function ucp_worker_signal(worker)
+@checked function ucp_worker_signal(worker)
     @ccall libucp.ucp_worker_signal(worker::ucp_worker_h)::ucs_status_t
 end
 
-function ucp_listener_create(worker, params, listener_p)
-    @ccall libucp.ucp_listener_create(worker::ucp_worker_h, params::Ptr{ucp_listener_params_t}, listener_p::Ptr{ucp_listener_h})::ucs_status_t
+@checked function ucp_listener_create(worker, params, listener_p)
+    @ccall libucp.ucp_listener_create(
+        worker::ucp_worker_h,
+        params::Ptr{ucp_listener_params_t},
+        listener_p::Ptr{ucp_listener_h},
+    )::ucs_status_t
 end
 
 function ucp_listener_destroy(listener)
     @ccall libucp.ucp_listener_destroy(listener::ucp_listener_h)::Cvoid
 end
 
-function ucp_listener_query(listener, attr)
+@checked function ucp_listener_query(listener, attr)
     @ccall libucp.ucp_listener_query(listener::ucp_listener_h, attr::Ptr{ucp_listener_attr_t})::ucs_status_t
 end
 
-function ucp_conn_request_query(conn_request, attr)
-    @ccall libucp.ucp_conn_request_query(conn_request::ucp_conn_request_h, attr::Ptr{ucp_conn_request_attr_t})::ucs_status_t
+@checked function ucp_conn_request_query(conn_request, attr)
+    @ccall libucp.ucp_conn_request_query(
+        conn_request::ucp_conn_request_h,
+        attr::Ptr{ucp_conn_request_attr_t},
+    )::ucs_status_t
 end
 
-function ucp_request_query(request, attr)
+@checked function ucp_request_query(request, attr)
     @ccall libucp.ucp_request_query(request::Ptr{Cvoid}, attr::Ptr{ucp_request_attr_t})::ucs_status_t
 end
 
-function ucp_ep_create(worker, params, ep_p)
+@checked function ucp_ep_create(worker, params, ep_p)
     @ccall libucp.ucp_ep_create(worker::ucp_worker_h, params::Ptr{ucp_ep_params_t}, ep_p::Ptr{ucp_ep_h})::ucs_status_t
 end
 
@@ -1211,7 +1491,7 @@ function ucp_ep_close_nbx(ep, param)
     @ccall libucp.ucp_ep_close_nbx(ep::ucp_ep_h, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
 end
 
-function ucp_listener_reject(listener, conn_request)
+@checked function ucp_listener_reject(listener, conn_request)
     @ccall libucp.ucp_listener_reject(listener::ucp_listener_h, conn_request::ucp_conn_request_h)::ucs_status_t
 end
 
@@ -1223,19 +1503,27 @@ function ucp_ep_flush_nbx(ep, param)
     @ccall libucp.ucp_ep_flush_nbx(ep::ucp_ep_h, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
 end
 
-function ucp_ep_evaluate_perf(ep, param, attr)
-    @ccall libucp.ucp_ep_evaluate_perf(ep::ucp_ep_h, param::Ptr{ucp_ep_evaluate_perf_param_t}, attr::Ptr{ucp_ep_evaluate_perf_attr_t})::ucs_status_t
+@checked function ucp_ep_evaluate_perf(ep, param, attr)
+    @ccall libucp.ucp_ep_evaluate_perf(
+        ep::ucp_ep_h,
+        param::Ptr{ucp_ep_evaluate_perf_param_t},
+        attr::Ptr{ucp_ep_evaluate_perf_attr_t},
+    )::ucs_status_t
 end
 
-function ucp_mem_map(context, params, memh_p)
-    @ccall libucp.ucp_mem_map(context::ucp_context_h, params::Ptr{ucp_mem_map_params_t}, memh_p::Ptr{ucp_mem_h})::ucs_status_t
+@checked function ucp_mem_map(context, params, memh_p)
+    @ccall libucp.ucp_mem_map(
+        context::ucp_context_h,
+        params::Ptr{ucp_mem_map_params_t},
+        memh_p::Ptr{ucp_mem_h},
+    )::ucs_status_t
 end
 
-function ucp_mem_unmap(context, memh)
+@checked function ucp_mem_unmap(context, memh)
     @ccall libucp.ucp_mem_unmap(context::ucp_context_h, memh::ucp_mem_h)::ucs_status_t
 end
 
-function ucp_mem_query(memh, attr)
+@checked function ucp_mem_query(memh, attr)
     @ccall libucp.ucp_mem_query(memh::ucp_mem_h, attr::Ptr{ucp_mem_attr_t})::ucs_status_t
 end
 
@@ -1259,8 +1547,12 @@ end
 
 const ucp_mem_advise_params_t = ucp_mem_advise_params
 
-function ucp_mem_advise(context, memh, params)
-    @ccall libucp.ucp_mem_advise(context::ucp_context_h, memh::ucp_mem_h, params::Ptr{ucp_mem_advise_params_t})::ucs_status_t
+@checked function ucp_mem_advise(context, memh, params)
+    @ccall libucp.ucp_mem_advise(
+        context::ucp_context_h,
+        memh::ucp_mem_h,
+        params::Ptr{ucp_mem_advise_params_t},
+    )::ucs_status_t
 end
 
 @cenum ucp_memh_pack_params_field::UInt32 begin
@@ -1278,8 +1570,13 @@ end
 
 const ucp_memh_pack_params_t = ucp_memh_pack_params
 
-function ucp_memh_pack(memh, params, buffer_p, buffer_size_p)
-    @ccall libucp.ucp_memh_pack(memh::ucp_mem_h, params::Ptr{ucp_memh_pack_params_t}, buffer_p::Ptr{Ptr{Cvoid}}, buffer_size_p::Ptr{Csize_t})::ucs_status_t
+@checked function ucp_memh_pack(memh, params, buffer_p, buffer_size_p)
+    @ccall libucp.ucp_memh_pack(
+        memh::ucp_mem_h,
+        params::Ptr{ucp_memh_pack_params_t},
+        buffer_p::Ptr{Ptr{Cvoid}},
+        buffer_size_p::Ptr{Csize_t},
+    )::ucs_status_t
 end
 
 struct ucp_memh_buffer_release_params
@@ -1292,11 +1589,11 @@ function ucp_memh_buffer_release(buffer, params)
     @ccall libucp.ucp_memh_buffer_release(buffer::Ptr{Cvoid}, params::Ptr{ucp_memh_buffer_release_params_t})::Cvoid
 end
 
-function ucp_ep_rkey_unpack(ep, rkey_buffer, rkey_p)
+@checked function ucp_ep_rkey_unpack(ep, rkey_buffer, rkey_p)
     @ccall libucp.ucp_ep_rkey_unpack(ep::ucp_ep_h, rkey_buffer::Ptr{Cvoid}, rkey_p::Ptr{ucp_rkey_h})::ucs_status_t
 end
 
-function ucp_rkey_ptr(rkey, raddr, addr_p)
+@checked function ucp_rkey_ptr(rkey, raddr, addr_p)
     @ccall libucp.ucp_rkey_ptr(rkey::ucp_rkey_h, raddr::UInt64, addr_p::Ptr{Ptr{Cvoid}})::ucs_status_t
 end
 
@@ -1304,16 +1601,30 @@ function ucp_rkey_destroy(rkey)
     @ccall libucp.ucp_rkey_destroy(rkey::ucp_rkey_h)::Cvoid
 end
 
-function ucp_worker_set_am_recv_handler(worker, param)
+@checked function ucp_worker_set_am_recv_handler(worker, param)
     @ccall libucp.ucp_worker_set_am_recv_handler(worker::ucp_worker_h, param::Ptr{ucp_am_handler_param_t})::ucs_status_t
 end
 
 function ucp_am_send_nbx(ep, id, header, header_length, buffer, count, param)
-    @ccall libucp.ucp_am_send_nbx(ep::ucp_ep_h, id::Cuint, header::Ptr{Cvoid}, header_length::Csize_t, buffer::Ptr{Cvoid}, count::Csize_t, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_am_send_nbx(
+        ep::ucp_ep_h,
+        id::Cuint,
+        header::Ptr{Cvoid},
+        header_length::Csize_t,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_am_recv_data_nbx(worker, data_desc, buffer, count, param)
-    @ccall libucp.ucp_am_recv_data_nbx(worker::ucp_worker_h, data_desc::Ptr{Cvoid}, buffer::Ptr{Cvoid}, count::Csize_t, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_am_recv_data_nbx(
+        worker::ucp_worker_h,
+        data_desc::Ptr{Cvoid},
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_am_data_release(worker, data)
@@ -1321,19 +1632,42 @@ function ucp_am_data_release(worker, data)
 end
 
 function ucp_stream_send_nbx(ep, buffer, count, param)
-    @ccall libucp.ucp_stream_send_nbx(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_stream_send_nbx(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_tag_send_nbx(ep, buffer, count, tag, param)
-    @ccall libucp.ucp_tag_send_nbx(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, tag::ucp_tag_t, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_send_nbx(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        tag::ucp_tag_t,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_tag_send_sync_nbx(ep, buffer, count, tag, param)
-    @ccall libucp.ucp_tag_send_sync_nbx(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, tag::ucp_tag_t, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_send_sync_nbx(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        tag::ucp_tag_t,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_stream_recv_nbx(ep, buffer, count, length, param)
-    @ccall libucp.ucp_stream_recv_nbx(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, length::Ptr{Csize_t}, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_stream_recv_nbx(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        length::Ptr{Csize_t},
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_stream_recv_data_nb(ep, length)
@@ -1341,38 +1675,79 @@ function ucp_stream_recv_data_nb(ep, length)
 end
 
 function ucp_tag_recv_nbx(worker, buffer, count, tag, tag_mask, param)
-    @ccall libucp.ucp_tag_recv_nbx(worker::ucp_worker_h, buffer::Ptr{Cvoid}, count::Csize_t, tag::ucp_tag_t, tag_mask::ucp_tag_t, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_recv_nbx(
+        worker::ucp_worker_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        tag::ucp_tag_t,
+        tag_mask::ucp_tag_t,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_tag_probe_nb(worker, tag, tag_mask, remove, info)
-    @ccall libucp.ucp_tag_probe_nb(worker::ucp_worker_h, tag::ucp_tag_t, tag_mask::ucp_tag_t, remove::Cint, info::Ptr{ucp_tag_recv_info_t})::ucp_tag_message_h
+    @ccall libucp.ucp_tag_probe_nb(
+        worker::ucp_worker_h,
+        tag::ucp_tag_t,
+        tag_mask::ucp_tag_t,
+        remove::Cint,
+        info::Ptr{ucp_tag_recv_info_t},
+    )::ucp_tag_message_h
 end
 
 function ucp_tag_msg_recv_nbx(worker, buffer, count, message, param)
-    @ccall libucp.ucp_tag_msg_recv_nbx(worker::ucp_worker_h, buffer::Ptr{Cvoid}, count::Csize_t, message::ucp_tag_message_h, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_tag_msg_recv_nbx(
+        worker::ucp_worker_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        message::ucp_tag_message_h,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_put_nbx(ep, buffer, count, remote_addr, rkey, param)
-    @ccall libucp.ucp_put_nbx(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_put_nbx(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_get_nbx(ep, buffer, count, remote_addr, rkey, param)
-    @ccall libucp.ucp_get_nbx(ep::ucp_ep_h, buffer::Ptr{Cvoid}, count::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_get_nbx(
+        ep::ucp_ep_h,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
 function ucp_atomic_op_nbx(ep, opcode, buffer, count, remote_addr, rkey, param)
-    @ccall libucp.ucp_atomic_op_nbx(ep::ucp_ep_h, opcode::ucp_atomic_op_t, buffer::Ptr{Cvoid}, count::Csize_t, remote_addr::UInt64, rkey::ucp_rkey_h, param::Ptr{ucp_request_param_t})::ucs_status_ptr_t
+    @ccall libucp.ucp_atomic_op_nbx(
+        ep::ucp_ep_h,
+        opcode::ucp_atomic_op_t,
+        buffer::Ptr{Cvoid},
+        count::Csize_t,
+        remote_addr::UInt64,
+        rkey::ucp_rkey_h,
+        param::Ptr{ucp_request_param_t},
+    )::ucs_status_ptr_t
 end
 
-function ucp_request_check_status(request)
+@checked function ucp_request_check_status(request)
     @ccall libucp.ucp_request_check_status(request::Ptr{Cvoid})::ucs_status_t
 end
 
-function ucp_tag_recv_request_test(request, info)
+@checked function ucp_tag_recv_request_test(request, info)
     @ccall libucp.ucp_tag_recv_request_test(request::Ptr{Cvoid}, info::Ptr{ucp_tag_recv_info_t})::ucs_status_t
 end
 
-function ucp_stream_recv_request_test(request, length_p)
+@checked function ucp_stream_recv_request_test(request, length_p)
     @ccall libucp.ucp_stream_recv_request_test(request::Ptr{Cvoid}, length_p::Ptr{Csize_t})::ucs_status_t
 end
 
@@ -1388,19 +1763,23 @@ function ucp_request_free(request)
     @ccall libucp.ucp_request_free(request::Ptr{Cvoid})::Cvoid
 end
 
-function ucp_dt_create_generic(ops, context, datatype_p)
-    @ccall libucp.ucp_dt_create_generic(ops::Ptr{ucp_generic_dt_ops_t}, context::Ptr{Cvoid}, datatype_p::Ptr{ucp_datatype_t})::ucs_status_t
+@checked function ucp_dt_create_generic(ops, context, datatype_p)
+    @ccall libucp.ucp_dt_create_generic(
+        ops::Ptr{ucp_generic_dt_ops_t},
+        context::Ptr{Cvoid},
+        datatype_p::Ptr{ucp_datatype_t},
+    )::ucs_status_t
 end
 
 function ucp_dt_destroy(datatype)
     @ccall libucp.ucp_dt_destroy(datatype::ucp_datatype_t)::Cvoid
 end
 
-function ucp_dt_query(datatype, attr)
+@checked function ucp_dt_query(datatype, attr)
     @ccall libucp.ucp_dt_query(datatype::ucp_datatype_t, attr::Ptr{ucp_datatype_attr_t})::ucs_status_t
 end
 
-function ucp_worker_fence(worker)
+@checked function ucp_worker_fence(worker)
     @ccall libucp.ucp_worker_fence(worker::ucp_worker_h)::ucs_status_t
 end
 
@@ -1418,7 +1797,7 @@ end
 
 struct ucp_ep_attr
     field_mask::UInt64
-    name::NTuple{32, Cchar}
+    name::NTuple{32,Cchar}
     local_sockaddr::sockaddr_storage
     remote_sockaddr::sockaddr_storage
     transports::ucp_transports_t
@@ -1427,13 +1806,15 @@ end
 
 const ucp_ep_attr_t = ucp_ep_attr
 
-function ucp_ep_query(ep, attr)
+@checked function ucp_ep_query(ep, attr)
     @ccall libucp.ucp_ep_query(ep::ucp_ep_h, attr::Ptr{ucp_ep_attr_t})::ucs_status_t
 end
 
 const UCS_ALLOCA_MAX_SIZE = 1200
 
-const UCS_MEMORY_TYPES_CPU_ACCESSIBLE = ((UCS_BIT(UCS_MEMORY_TYPE_HOST) | UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED)) | UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST)) | UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED)
+const UCS_MEMORY_TYPES_CPU_ACCESSIBLE =
+    ((UCS_BIT(UCS_MEMORY_TYPE_HOST) | UCS_BIT(UCS_MEMORY_TYPE_ROCM_MANAGED)) | UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST)) |
+    UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED)
 
 const UCP_ENTITY_NAME_MAX = 32
 
@@ -1448,5 +1829,12 @@ const UCP_API_MINOR = 20
 const UCP_API_VERSION = UCP_VERSION(1, 20)
 
 const UCS_CPU_SETSIZE = 1024
+
+# Defined here rather than in the prologue because it uses `ucs_status_t`, which
+# is defined after the prologue.
+struct UCXException <: Exception
+    status::ucs_status_t
+end
+
 
 end # module


### PR DESCRIPTION
This has a few related commits that I've tried to keep atomic for easier review
- 075fc95: removes some code that went through `UCX` for looking up properties, like `UCX.Cint`.
- 3eb655c: generates accessor methods for the UCX structs. We now generate a 32bit and 64bit version of the bindings because the accessors use hardcoded numeric offsets, and pointer fields will have different sizes on 32/64bit.
- Make a `zeroedref()` helper function to create the struct refs, which uses the new accessor methods internally. The advantage being that all the struct initialization code is in the same place, and we can rely on the generated bindings more.